### PR TITLE
Use path rather than absoluteString with replace

### DIFF
--- a/BandsintownContactPhotoProvider.m
+++ b/BandsintownContactPhotoProvider.m
@@ -30,9 +30,8 @@
     UNNotificationContent *content = [notificationRequest content];
     UNNotificationAttachment *attachment = [content attachments][0];
     if (!attachment) return nil;
-    NSString *imageURL = [attachment URL].absoluteString;
-
-    imageURL = [imageURL stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+  
+    NSString *imageURL = [attachment URL].path;
     UIImage *image = [UIImage imageWithContentsOfFile:imageURL];
 
     return [NSClassFromString(@"DDNotificationContactPhotoPromiseOffer") offerInstantlyResolvingPromiseWithPhotoIdentifier:imageURL image:image];


### PR DESCRIPTION
NSURL's path is in the format UIImage wants, so this PR changes it to use that rather than getting absoluteString and then replacing file:// with blank string